### PR TITLE
Switch to generic Evernote download url. Fixes #6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
 
 ## Usage
 
+To use the latest version of Evernote:
 ```puppet
 include evernote
 ```
+
+To use a specific version of Evernote:
+```puppet
+class { 'evernote':
+  sourceUri => 'https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_5.6.0_450741.dmg'
+}
+```
+
 
 ## Required Puppet Modules
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,11 @@
 # Examples
 #
 #   include evernote
-class evernote {
+class evernote (
+  $sourceUri = 'https://evernote.com/download/get.php?file=EvernoteMac&boxen=/evernote_latest.dmg',
+) {
   package { 'evernote':
     provider => 'appdmg_eula',
-    source   => 'http://cdn1.evernote.com/mac/release/Evernote_402634.dmg'
+    source   => $sourceUri,
   }
 }

--- a/spec/classes/evernote_spec.rb
+++ b/spec/classes/evernote_spec.rb
@@ -9,7 +9,7 @@ describe 'evernote' do
 
   it do
     should contain_package('evernote').with({
-      :source   => 'http://cdn1.evernote.com/mac/release/Evernote_402634.dmg',
+      :source   => 'https://evernote.com/download/get.php?file=EvernoteMac&boxen=/evernote_latest.dmg',
       :provider => 'appdmg_eula'
     })
   end

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,2 +1,2 @@
-mod 'boxen', '2.1.0', :github_tarball => 'boxen/puppet-boxen'
-mod 'stdlib', '4.0.0', :github_tarball => "puppetlabs/puppetlabs-stdlib"
+mod 'boxen', '3.6.2', :github_tarball => 'boxen/puppet-boxen'
+mod 'stdlib', '4.2.1', :github_tarball => "puppetlabs/puppetlabs-stdlib"


### PR DESCRIPTION
Rather than updating puppet-evernote every time Evernote releases (which is fairly frequently), I'm hoping we can use the URI "https://evernote.com/download/get.php?file=EvernoteMac" to grab the latest. Because the package provider is looking for a URI ending in '.dmg' I've tacked on "&boxen=/evernote_latest.dmg" to the end of the query string which appears to do the trick.

Additionally I've made the source URI a variable which would allow someone to specify a different URI (e.g. to pin to a specific version).

To test with your-boxen, change your evernote mod in Puppetfile to:

```
github "evernote",   "2.0.6.901", :repo => "webbj74/puppet-evernote"
```

And in your manifests either:

```
include evernote
```

or if you want to specify the download URI:

```
class { 'evernote':
  sourceUri => 'https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_5.6.0_450741.dmg'
}
```

I also updated the test's Puppetfile and the README.md
