### PR TITLE
Add deprecation notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+**This Boxen module is now deprecated. The advised method for installing applications with Boxen is to now use [homebrew-cask](http://caskroom.io/). Add the following to your manifest to install Evernote using brewcask:**
+
+```puppet
+package { 'evernote': provider => 'brewcask' }
+```
+
+---
+
 # Evernote Puppet Module for Boxen
 
 [![Build Status](https://travis-ci.org/boxen/puppet-evernote.png?branch=master)](https://travis-ci.org/boxen/puppet-evernote)


### PR DESCRIPTION
Boxen is switching to use brewcask instead of app wrapper modules. This PR adds a notice to the README.md deprecating the module in favour of installing with brewcask with instructions on how to install.