### PR TITLE
Update Ruby Version to allow Highline to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:
-  - "1.8.7"
+  - "1.9.3"


### PR DESCRIPTION
Update Ruby Version to allow Highline to be installed during Travis testing.